### PR TITLE
fix: fixed the responsive stying errors in blog and cta

### DIFF
--- a/src/components/CTA/cta.css
+++ b/src/components/CTA/cta.css
@@ -57,27 +57,27 @@
 }
 
 @media screen and (max-width: 650px) {
-  .gpt3__cta {
+  .gpt__cta {
     flex-direction: column;
   }
 
-  .gpt3__cta-btn {
+  .gpt__cta-btn {
     margin: 2rem 0 0;
   }
 }
 
 @media screen and (max-width: 550px) {
-  .gpt3__cta {
+  .gpt__cta {
     flex-direction: column;
     margin: 4rem 2rem;
   }
 
-  .gpt3__cta-content h3 {
+  .gpt__cta-content h3 {
     font-size: 18px;
     line-height: 32px;
   }
 
-  .gpt3__cta-btn button {
+  .gpt__cta-btn button {
     font-size: 14px;
     line-height: 28px;
   }

--- a/src/containers/blog/blog.css
+++ b/src/containers/blog/blog.css
@@ -36,40 +36,40 @@
 }
 
 @media screen and (max-width: 990px) {
-  .gpt3__blog-container {
+  .gpt__blog-container {
     flex-direction: column-reverse;
   }
 
-  .gpt3__blog-container_groupA {
+  .gpt__blog-container__groupA {
     margin: 2rem 0;
   }
 
-  .gpt3__blog-container_groupA .gpt3__blog-container_article {
+  .gpt__blog-container__groupA .gpt__blog-container__article {
     width: 48%;
   }
 
-  .gpt3__blog-container_groupA .gpt3__blog-container_article-image {
+  .gpt__blog-container__groupA .gpt__blog-container__article-image {
     height: 250px;
   }
 }
 
 @media screen and (max-width: 700px) {
-  .gpt3__blog-container_groupB {
+  .gpt__blog-container__groupB {
     grid-template-columns: repeat(1, 1fr);
   }
 
-  .gpt3__blog-container_groupA .gpt3__blog-container_article {
+  .gpt__blog-container__groupA .gpt__blog-container__article {
     width: 100%;
   }
 
-  .gpt3__blog-heading h1 {
+  .gpt__blog-heading h1 {
     font-size: 46px;
     line-height: 52px;
   }
 }
 
 @media screen and (max-width: 550px) {
-  .gpt3__blog-heading h1 {
+  .gpt__blog-heading h1 {
     font-size: 34px;
     line-height: 42px;
   }


### PR DESCRIPTION
This pull request includes changes to the CSS files for the `CTA` and `blog` components to update class names. The most important changes involve renaming the class names to follow a consistent naming convention without the '3' suffix.

Changes to `CTA` component:

* [`src/components/CTA/cta.css`](diffhunk://#diff-f21e6d05a3ece67e5a48415784440eb668bcdaf45073437264f5be8ac33998c5L60-R80): Updated class names from `.gpt3__cta` to `.gpt__cta`, `.gpt3__cta-btn` to `.gpt__cta-btn`, and other related class names.

Changes to `blog` component:

* [`src/containers/blog/blog.css`](diffhunk://#diff-5b16c544668f8702d901a916e45ed3b8af92e50e56cb6bee0064dc601e7c45cfL39-R72): Updated class names from `.gpt3__blog-container` to `.gpt__blog-container`, `.gpt3__blog-container_groupA` to `.gpt__blog-container__groupA`, and other related class names.